### PR TITLE
Support pidexc command

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -47,5 +47,10 @@ var (
 			},
 			Action: logContainer,
 		},
+		{
+			Name:   "pidexc",
+			Usage:  "Print containers whose process number exceeds a specified number",
+			Action: pidExcContainer,
+		},
 	}
 )

--- a/cli/pidexcd.go
+++ b/cli/pidexcd.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"os"
+
+	"../cgroups"
+	"../docker"
+	log "github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+)
+
+// pidExcdContainer returns containers whose process number exceeds a specified number
+func pidExcContainer(c *cli.Context) {
+	if len(c.Args()) != 1 {
+		log.Fatalf("Pidexc command takes exact one argument. See '%s pidexcd --help'.", c.App.Name)
+	}
+
+	excdNumStr := c.Args()[0]
+
+	excdNum, err := strconv.Atoi(excdNumStr)
+	if err != nil {
+		log.Fatalf("Pidexc command's argument should be positive, invalid input (%s)", excdNumStr)
+		os.Exit(1)
+	}
+
+	containers, err := docker.Containers()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var exist = false
+	for _, container := range containers {
+
+		ID := container.ID
+
+		num, err := cgroups.ContainerPidNum(ID)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+
+		if num > excdNum {
+			fmt.Printf("Container(%s)'s process number is %d, which exceeds %d\n", ID, num, excdNum)
+			exist = true
+		}
+	}
+	if !exist {
+		fmt.Printf("There are no containers whose process number exceeds %d\n", excdNum)
+	}
+
+}

--- a/cli/pidexcd.go
+++ b/cli/pidexcd.go
@@ -35,7 +35,7 @@ func pidExcContainer(c *cli.Context) {
 
 		num, err := cgroups.ContainerPidNum(ID)
 		if err != nil {
-			log.Fatal(err.Error())
+			log.Fatal(err)
 		}
 
 		if num > excdNum {

--- a/cli/pidexcd.go
+++ b/cli/pidexcd.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"strconv"
-	"os"
 
 	"../cgroups"
 	"../docker"
@@ -21,8 +20,7 @@ func pidExcContainer(c *cli.Context) {
 
 	excdNum, err := strconv.Atoi(excdNumStr)
 	if err != nil {
-		log.Fatalf("Pidexc command's argument should be positive, invalid input (%s)", excdNumStr)
-		os.Exit(1)
+		log.Fatalf("Pidexc command's argument is invalid (%s)", excdNumStr)
 	}
 
 	containers, err := docker.Containers()


### PR DESCRIPTION
I read your roadmap and I add the feature which print containers whose process number exceeds a specified number,  hope it works.

Below is my test result:

```
[root@VM_226_193_centos daoker]# ./daoker pidexc 0
Container(4df89d5d6f46970aae665256b9dd2b495c4cfc6b5ad6972bbe416de98ca0f437)'s process number is 1, which exceeds 0
Container(bd3651418999eb4998470495feb56c2454770a9959c91a571438b23b728d4516)'s process number is 2, which exceeds 0

[root@VM_226_193_centos daoker]# ./daoker pidexc 1
Container(bd3651418999eb4998470495feb56c2454770a9959c91a571438b23b728d4516)'s process number is 2, which exceeds 1

[root@VM_226_193_centos daoker]# ./daoker pidexc 2
There are no containers whose process number exceeds 2
```
